### PR TITLE
migrating to `nocairosvg` from `cairosvg`

### DIFF
--- a/gui_option/composite_markup_generator_with_GUI.py
+++ b/gui_option/composite_markup_generator_with_GUI.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
 import os
+# Get the current PATH
+if os.name == 'nt': # if os is windows
+    path = os.environ['PATH'].replace("C:\\Program Files\\GTK3-Runtime Win64\\bin","C:\\Program Files\\GTK3-Runtime Win64\\bin\\")
+    os.environ['PATH'] = path
+#print(os.environ['PATH'])
+
+import sys
 import re
 import collections
 import sqlite3
-import cairosvg
+import nocairosvg
 from PIL import Image
 import io
 
@@ -174,7 +180,7 @@ def overlay_svg_on_jpg(
 
     try:
         # Convert SVG -> PNG
-        cairosvg.svg2png(
+        nocairosvg.svg2png(
             url=svg_path,
             write_to=temp_overlay,
             output_width=final_width,


### PR DESCRIPTION
trying to standardize python script across windows and linux, hence hotswapping with `nocairosvg`. Also have if condition after `import os` to address trailing slash directory path bug for GTK Windows Installation. 

Finding that the python script work both on Windows and Linux, but the `pyinstaller`-generated executable works on Linux but silently fails on Windows (generates directories, but does not actually write the composite markup files). Investigating still.